### PR TITLE
global seed & reproducibility

### DIFF
--- a/src/protify/data/data_mixin.py
+++ b/src/protify/data/data_mixin.py
@@ -8,9 +8,10 @@ from glob import glob
 from pandas import read_csv, read_excel
 from datasets import load_dataset, Dataset
 from dataclasses import dataclass
+
 from utils import print_message
-from .supported_datasets import supported_datasets, standard_data_benchmark
 from seed_utils import get_global_seed
+from .supported_datasets import supported_datasets, standard_data_benchmark
 
 AMINO_ACIDS = set('LAGVSERTIPDKQNFYMHWCXBUOZ*')
 CODONS = set('aA@bB#$%rRnNdDcCeEqQ^G&ghHiIj+MmlJLkK(fFpPoO=szZwSXTtxWyYuvUV]})')
@@ -261,10 +262,10 @@ class DataMixin:
             except:
                 # No valid or test set, make 10% splits randomly
                 seed = get_global_seed() if get_global_seed() is not None else 42
-                train_set = dataset['train'].train_test_split(test_size=0.2, seed=seed)
+                train_set = dataset['train'].train_test_split(test_size=0.2, seed=seed + 1)
                 valid_set = train_set['test']
                 train_set = train_set['train']
-                test_set = train_set.train_test_split(test_size=0.5, seed=seed)
+                test_set = train_set.train_test_split(test_size=0.5, seed=seed + 2)
                 test_set = test_set['test']
 
             if not ppi:

--- a/src/protify/data/data_mixin.py
+++ b/src/protify/data/data_mixin.py
@@ -10,7 +10,7 @@ from datasets import load_dataset, Dataset
 from dataclasses import dataclass
 from utils import print_message
 from .supported_datasets import supported_datasets, standard_data_benchmark
-
+from ..seed_utils import get_global_seed
 
 AMINO_ACIDS = set('LAGVSERTIPDKQNFYMHWCXBUOZ*')
 CODONS = set('aA@bB#$%rRnNdDcCeEqQ^G&ghHiIj+MmlJLkK(fFpPoO=szZwSXTtxWyYuvUV]})')
@@ -260,10 +260,11 @@ class DataMixin:
                 train_set, valid_set, test_set = dataset['train'], dataset['valid'], dataset['test']
             except:
                 # No valid or test set, make 10% splits randomly
-                train_set = dataset['train'].train_test_split(test_size=0.2, seed=42)
+                seed = get_global_seed() if get_global_seed() is not None else 42
+                train_set = dataset['train'].train_test_split(test_size=0.2, seed=seed)
                 valid_set = train_set['test']
                 train_set = train_set['train']
-                test_set = train_set.train_test_split(test_size=0.5, seed=42)
+                test_set = train_set.train_test_split(test_size=0.5, seed=seed)
                 test_set = test_set['test']
 
             if not ppi:

--- a/src/protify/data/data_mixin.py
+++ b/src/protify/data/data_mixin.py
@@ -10,7 +10,7 @@ from datasets import load_dataset, Dataset
 from dataclasses import dataclass
 from utils import print_message
 from .supported_datasets import supported_datasets, standard_data_benchmark
-from ..seed_utils import get_global_seed
+from seed_utils import get_global_seed
 
 AMINO_ACIDS = set('LAGVSERTIPDKQNFYMHWCXBUOZ*')
 CODONS = set('aA@bB#$%rRnNdDcCeEqQ^G&ghHiIj+MmlJLkK(fFpPoO=szZwSXTtxWyYuvUV]})')

--- a/src/protify/embedder.py
+++ b/src/protify/embedder.py
@@ -8,6 +8,7 @@ from tqdm.auto import tqdm
 from dataclasses import dataclass
 from typing import Optional, Callable, List
 from huggingface_hub import hf_hub_download
+from seed_utils import seed_worker, dataloader_generator, get_global_seed
 
 from data.dataset_classes import SimpleProteinDataset
 from base_models.get_base_models import get_base_model
@@ -199,7 +200,9 @@ class Embedder:
             prefetch_factor=2 if self.num_workers > 0 else None,
             collate_fn=collate_fn,
             shuffle=False,
-            pin_memory=True
+            pin_memory=True,
+            worker_init_fn=seed_worker,
+            generator=dataloader_generator(get_global_seed())
         )
 
         if self.sql:

--- a/src/protify/logger.py
+++ b/src/protify/logger.py
@@ -12,6 +12,7 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 from utils import print_message
+from seed_utils import set_global_seed
 
 
 def log_method_calls(func):
@@ -34,6 +35,7 @@ class MetricsLogger:
     def __init__(self, args):
         self.logger_args = args
         self._section_break = '\n' + '=' * 55 + '\n'
+        self.seed_value = None
 
     def _start_file(self):
         args = self.logger_args
@@ -73,6 +75,9 @@ class MetricsLogger:
     def _write_args(self):
         with open(self.log_file, 'a') as f:
             f.write(self._section_break)
+            # Write the seed value first if it exists
+            if self.seed_value is not None:
+                f.write(f"_global_seed:\t{self.seed_value}\n")
             for k, v in self.logger_args.__dict__.items():
                 if 'token' not in k.lower() and 'api' not in k.lower():
                     f.write(f"{k}:\t{v}\n")
@@ -80,6 +85,13 @@ class MetricsLogger:
 
     def start_log_main(self):
         self._start_file()
+        
+        # Set the global seed before writing args
+        # Use provided seed or generate from timestamp
+        seed = getattr(self.logger_args, 'seed', None)
+        if seed is None or seed < 0:  # Allow seed=0 but treat negative as unset
+            seed = None  # Will use timestamp in set_global_seed
+        self.seed_value = set_global_seed(seed)
 
         with open(self.log_file, 'w') as f:
             now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
@@ -91,9 +103,17 @@ class MetricsLogger:
             self._write_args()
 
         self._minimial_logger()
+        self.logger.info(f"Global random seed initialized to: {self.seed_value}")
 
     def start_log_gui(self):
         self._start_file()
+        
+        # Set the global seed before writing to file
+        seed = getattr(self.logger_args, 'seed', None)
+        if seed is None or seed < 0:
+            seed = None
+        self.seed_value = set_global_seed(seed)
+        
         with open(self.log_file, 'w') as f:
             now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
             if self.logger_args.replay_path is not None:
@@ -102,7 +122,12 @@ class MetricsLogger:
             header = f"=== Logging session started at {now} ===\n"
             f.write(header)
             f.write(self._section_break)
+            # Write seed value for GUI mode
+            if self.seed_value is not None:
+                f.write(f"_global_seed:\t{self.seed_value}\n")
+            f.write(self._section_break)
         self._minimial_logger()
+        self.logger.info(f"Global random seed initialized to: {self.seed_value}")
 
     def load_tsv(self):
         """Load existing TSV data into self.logger_data_tracking (row=dataset, col=model)."""
@@ -244,12 +269,14 @@ class LogReplayer:
         self.log_file = Path(log_file_path)
         self.arguments = {}
         self.method_calls = []
+        self.global_seed = None
 
     def parse_log(self):
         """
         Reads the log file line by line. Extracts:
           1) Global arguments into self.arguments
           2) Method calls into self.method_calls (in order)
+          3) Global seed value if present
         """
         if not self.log_file.exists():
             raise FileNotFoundError(f"Log file not found: {self.log_file}")
@@ -260,8 +287,15 @@ class LogReplayer:
                 if line.startswith('='):
                     continue
                 elif line.startswith('INFO'):
-                    method = line.split(': ')[-1].strip()
-                    self.method_calls.append(method)
+                    # Check if this is the seed initialization message
+                    if 'Global random seed initialized to:' in line:
+                        try:
+                            self.global_seed = int(line.split(':')[-1].strip())
+                        except:
+                            pass
+                    else:
+                        method = line.split(': ')[-1].strip()
+                        self.method_calls.append(method)
                 elif ':\t' in line:
                     key, value = line.split(':\t')
                     key, value = key.strip(), value.strip()
@@ -269,7 +303,16 @@ class LogReplayer:
                         value = ast.literal_eval(value)
                     except (ValueError, SyntaxError):
                         pass
-                    self.arguments[key] = value
+                    # Handle special _global_seed key
+                    if key == '_global_seed':
+                        self.global_seed = int(value)
+                    else:
+                        self.arguments[key] = value
+        
+        # Restore the global seed if found
+        if self.global_seed is not None:
+            set_global_seed(self.global_seed)
+            print_message(f"Restored global random seed to: {self.global_seed}")
 
         return SimpleNamespace(**self.arguments)
 

--- a/src/protify/logger.py
+++ b/src/protify/logger.py
@@ -12,7 +12,6 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 from utils import print_message
-from seed_utils import set_global_seed
 
 
 def log_method_calls(func):
@@ -35,7 +34,6 @@ class MetricsLogger:
     def __init__(self, args):
         self.logger_args = args
         self._section_break = '\n' + '=' * 55 + '\n'
-        self.seed_value = None
 
     def _start_file(self):
         args = self.logger_args
@@ -75,9 +73,6 @@ class MetricsLogger:
     def _write_args(self):
         with open(self.log_file, 'a') as f:
             f.write(self._section_break)
-            # Write the seed value first if it exists
-            if self.seed_value is not None:
-                f.write(f"_global_seed:\t{self.seed_value}\n")
             for k, v in self.logger_args.__dict__.items():
                 if 'token' not in k.lower() and 'api' not in k.lower():
                     f.write(f"{k}:\t{v}\n")
@@ -85,13 +80,6 @@ class MetricsLogger:
 
     def start_log_main(self):
         self._start_file()
-        
-        # Set the global seed before writing args
-        # Use provided seed or generate from timestamp
-        seed = getattr(self.logger_args, 'seed', None)
-        if seed is None or seed < 0:  # Allow seed=0 but treat negative as unset
-            seed = None  # Will use timestamp in set_global_seed
-        self.seed_value = set_global_seed(seed)
 
         with open(self.log_file, 'w') as f:
             now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
@@ -103,17 +91,9 @@ class MetricsLogger:
             self._write_args()
 
         self._minimial_logger()
-        self.logger.info(f"Global random seed initialized to: {self.seed_value}")
 
     def start_log_gui(self):
         self._start_file()
-        
-        # Set the global seed before writing to file
-        seed = getattr(self.logger_args, 'seed', None)
-        if seed is None or seed < 0:
-            seed = None
-        self.seed_value = set_global_seed(seed)
-        
         with open(self.log_file, 'w') as f:
             now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
             if self.logger_args.replay_path is not None:
@@ -122,12 +102,7 @@ class MetricsLogger:
             header = f"=== Logging session started at {now} ===\n"
             f.write(header)
             f.write(self._section_break)
-            # Write seed value for GUI mode
-            if self.seed_value is not None:
-                f.write(f"_global_seed:\t{self.seed_value}\n")
-            f.write(self._section_break)
         self._minimial_logger()
-        self.logger.info(f"Global random seed initialized to: {self.seed_value}")
 
     def load_tsv(self):
         """Load existing TSV data into self.logger_data_tracking (row=dataset, col=model)."""
@@ -269,14 +244,12 @@ class LogReplayer:
         self.log_file = Path(log_file_path)
         self.arguments = {}
         self.method_calls = []
-        self.global_seed = None
 
     def parse_log(self):
         """
         Reads the log file line by line. Extracts:
           1) Global arguments into self.arguments
           2) Method calls into self.method_calls (in order)
-          3) Global seed value if present
         """
         if not self.log_file.exists():
             raise FileNotFoundError(f"Log file not found: {self.log_file}")
@@ -287,15 +260,8 @@ class LogReplayer:
                 if line.startswith('='):
                     continue
                 elif line.startswith('INFO'):
-                    # Check if this is the seed initialization message
-                    if 'Global random seed initialized to:' in line:
-                        try:
-                            self.global_seed = int(line.split(':')[-1].strip())
-                        except:
-                            pass
-                    else:
-                        method = line.split(': ')[-1].strip()
-                        self.method_calls.append(method)
+                    method = line.split(': ')[-1].strip()
+                    self.method_calls.append(method)
                 elif ':\t' in line:
                     key, value = line.split(':\t')
                     key, value = key.strip(), value.strip()
@@ -303,16 +269,7 @@ class LogReplayer:
                         value = ast.literal_eval(value)
                     except (ValueError, SyntaxError):
                         pass
-                    # Handle special _global_seed key
-                    if key == '_global_seed':
-                        self.global_seed = int(value)
-                    else:
-                        self.arguments[key] = value
-        
-        # Restore the global seed if found
-        if self.global_seed is not None:
-            set_global_seed(self.global_seed)
-            print_message(f"Restored global random seed to: {self.global_seed}")
+                    self.arguments[key] = value
 
         return SimpleNamespace(**self.arguments)
 

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -100,7 +100,9 @@ def parse_arguments():
     #parser.add_argument("--optimizer", type=str, default='adamw', help='Optimizer.')
     parser.add_argument("--weight_decay", type=float, default=0.00, help="Weight decay.")
     parser.add_argument("--patience", type=int, default=1, help="Patience for early stopping.")
-    parser.add_argument("--seed", type=int, default=42, help="Seed for random number generation.")
+    parser.add_argument("--seed", type=int, default=None, help="Seed for reproducibility (if omitted, current time is used).")
+    parser.add_argument("--deterministic", action="store_true", default=False,
+                        help="Enable deterministic behavior for reproducibility (will slow down training).")
     parser.add_argument("--full_finetuning", action="store_true", default=False, help="Full finetuning (default: False).")
     parser.add_argument("--hybrid_probe", action="store_true", default=False, help="Hybrid probe (default: False).")
 
@@ -123,12 +125,25 @@ def parse_arguments():
         yaml_args.synthyra_api_key = args.synthyra_api_key
         yaml_args.wandb_api_key = args.wandb_api_key
         yaml_args.yaml_path = args.yaml_path
+        # Ensure seed and deterministic flags are present/propagated
+        if not hasattr(yaml_args, 'seed'):
+            yaml_args.seed = args.seed
+        yaml_args.deterministic = getattr(args, 'deterministic', False)
         return yaml_args
     else:
         return args
 
 if __name__ == "__main__":
     args = parse_arguments()
+
+    # Set global seed before doing anything else
+    try:
+        from seed_utils import set_global_seed
+        # If seed is None, set_global_seed will derive it from current time
+        chosen_seed = set_global_seed(getattr(args, 'seed', None), deterministic=getattr(args, 'deterministic', False))
+        args.seed = chosen_seed
+    except Exception:
+        pass
 
     if args.hf_home is not None:
         # Needs to happen before any HF imports
@@ -476,6 +491,18 @@ def main(args: SimpleNamespace):
         replayer = LogReplayer(args.replay_path)
         replay_args = replayer.parse_log()
         replay_args.replay_path = args.replay_path
+        # Re-apply seed using the replayed settings to ensure exact reproducibility
+        try:
+            from seed_utils import set_global_seed
+            # If no seed is present in replay, fall back to time-based seed
+            if not hasattr(replay_args, 'seed') or replay_args.seed is None:
+                replay_args.seed = None
+            if not hasattr(replay_args, 'deterministic') or replay_args.deterministic is None:
+                replay_args.deterministic = getattr(args, 'deterministic', False)
+            chosen_seed = set_global_seed(replay_args.seed, deterministic=replay_args.deterministic)
+            replay_args.seed = chosen_seed
+        except Exception:
+            pass
         main = MainProcess(replay_args, GUI=False)
         for k, v in main.full_args.__dict__.items():
             print(f"{k}:\t{v}")

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -70,7 +70,7 @@ def parse_arguments():
     # ----------------- ScikitArguments ----------------- # # TODO add to GUI
     parser.add_argument("--scikit_n_iter", type=int, default=10, help="Number of iterations for scikit model.")
     parser.add_argument("--scikit_cv", type=int, default=3, help="Number of cross-validation folds for scikit model.")
-    parser.add_argument("--scikit_random_state", type=int, default=42, help="Random state for scikit model.")
+    parser.add_argument("--scikit_random_state", type=int, default=None, help="Random state for scikit model (if None, uses global seed).")
     parser.add_argument("--scikit_model_name", type=str, default=None, help="Name of the scikit model to use.")
     parser.add_argument("--use_scikit", action="store_true", default=False, help="Use scikit model (default: False).")
     parser.add_argument("--n_jobs", type=int, default=1, help="Number of processes to use in scikit.") # TODO integrate with GUI and main

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -32,7 +32,7 @@ def parse_arguments():
     # ----------------- DataArguments ----------------- #
     parser.add_argument("--delimiter", default=",", help="Delimiter for data.")
     parser.add_argument("--col_names", nargs="+", default=["seqs", "labels"], help="Column names.")
-    parser.add_argument("--max_length", type=int, default=1024, help="Maximum sequence length.")
+    parser.add_argument("--max_length", type=int, default=128, help="Maximum sequence length.")
     parser.add_argument("--trim", action="store_true", default=False,
                         help="Whether to trim sequences (default: False). If False, sequences are removed from the dataset if they are longer than max length. If True, they are truncated to max length."
                         )
@@ -125,25 +125,16 @@ def parse_arguments():
         yaml_args.synthyra_api_key = args.synthyra_api_key
         yaml_args.wandb_api_key = args.wandb_api_key
         yaml_args.yaml_path = args.yaml_path
-        # Ensure seed and deterministic flags are present/propagated
-        if not hasattr(yaml_args, 'seed'):
-            yaml_args.seed = args.seed
-        yaml_args.deterministic = getattr(args, 'deterministic', False)
+        yaml_args.seed = args.seed
+        yaml_args.deterministic = args.deterministic
         return yaml_args
     else:
         return args
 
-if __name__ == "__main__":
-    args = parse_arguments()
 
-    # Set global seed before doing anything else
-    try:
-        from seed_utils import set_global_seed
-        # If seed is None, set_global_seed will derive it from current time
-        chosen_seed = set_global_seed(getattr(args, 'seed', None), deterministic=getattr(args, 'deterministic', False))
-        args.seed = chosen_seed
-    except Exception:
-        pass
+if __name__ == "__main__":
+    # Settings that need to happen pre-imports
+    args = parse_arguments()
 
     if args.hf_home is not None:
         # Needs to happen before any HF imports
@@ -163,6 +154,12 @@ if __name__ == "__main__":
         print(f"TRANSFORMERS_CACHE: {os.environ['TRANSFORMERS_CACHE']}")
         print(f"HF_HUB_CACHE: {os.environ['HF_HUB_CACHE']}")
 
+    # Set global seed before doing anything else    
+    # If seed is None, set_global_seed will derive it from current time
+    from seed_utils import set_determinism
+    if args.deterministic:
+        set_determinism()
+
 
 import torch
 from torchinfo import summary
@@ -177,6 +174,7 @@ from embedder import EmbeddingArguments, Embedder
 from logger import MetricsLogger, log_method_calls
 from utils import torch_load, print_message
 from visualization.plot_result import create_plots
+from seed_utils import set_global_seed
 
 
 class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
@@ -486,6 +484,9 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
         
 
 def main(args: SimpleNamespace):
+    chosen_seed = set_global_seed(args.seed)
+    args.seed = chosen_seed
+
     if args.replay_path is not None:
         from logger import LogReplayer
         replayer = LogReplayer(args.replay_path)
@@ -493,7 +494,6 @@ def main(args: SimpleNamespace):
         replay_args.replay_path = args.replay_path
         # Re-apply seed using the replayed settings to ensure exact reproducibility
         try:
-            from seed_utils import set_global_seed
             # If no seed is present in replay, fall back to time-based seed
             if not hasattr(replay_args, 'seed') or replay_args.seed is None:
                 replay_args.seed = None

--- a/src/protify/model_components/transformer.py
+++ b/src/protify/model_components/transformer.py
@@ -118,7 +118,9 @@ class TransformerConfig(PretrainedConfig):
         expansion_ratio: float = 8 / 3,
         dropout: float = 0.1,
         rotary: bool = True,
+        **kwargs,
     ):
+        super().__init__(**kwargs)
         self.hidden_size = hidden_size
         self.n_heads = n_heads
         self.n_layers = n_layers

--- a/src/protify/probes/lazy_predict.py
+++ b/src/protify/probes/lazy_predict.py
@@ -22,6 +22,7 @@ from sklearn.metrics import (
     mean_squared_error,
 )
 from utils import print_message
+from ..seed_utils import get_sklearn_random_state
 warnings.filterwarnings("ignore")
 pd.set_option("display.precision", 2)
 pd.set_option("display.float_format", lambda x: "%.2f" % x)
@@ -239,7 +240,7 @@ class LazyClassifier:
         ignore_warnings=True,
         custom_metric=None,
         predictions=False,
-        random_state=42,
+        random_state=None,
         classifiers="all",
     ):
         self.verbose = verbose
@@ -247,7 +248,7 @@ class LazyClassifier:
         self.custom_metric = custom_metric
         self.predictions = predictions
         self.models = {}
-        self.random_state = random_state
+        self.random_state = random_state or get_sklearn_random_state()
         self.classifiers = classifiers
 
     def fit(self, X_train, X_test, y_train, y_test):
@@ -483,7 +484,7 @@ class LazyRegressor:
         ignore_warnings=True,
         custom_metric=None,
         predictions=False,
-        random_state=42,
+        random_state=None,
         regressors="all",
     ):
         self.verbose = verbose
@@ -491,7 +492,7 @@ class LazyRegressor:
         self.custom_metric = custom_metric
         self.predictions = predictions
         self.models = {}
-        self.random_state = random_state
+        self.random_state = random_state or get_sklearn_random_state()
         self.regressors = regressors
 
     def fit(self, X_train, X_test, y_train, y_test):

--- a/src/protify/probes/lazy_predict.py
+++ b/src/protify/probes/lazy_predict.py
@@ -22,7 +22,7 @@ from sklearn.metrics import (
     mean_squared_error,
 )
 from utils import print_message
-from ..seed_utils import get_sklearn_random_state
+from seed_utils import get_sklearn_random_state
 warnings.filterwarnings("ignore")
 pd.set_option("display.precision", 2)
 pd.set_option("display.float_format", lambda x: "%.2f" % x)

--- a/src/protify/probes/lazy_predict.py
+++ b/src/protify/probes/lazy_predict.py
@@ -22,7 +22,7 @@ from sklearn.metrics import (
     mean_squared_error,
 )
 from utils import print_message
-from seed_utils import get_sklearn_random_state
+from seed_utils import get_global_seed
 warnings.filterwarnings("ignore")
 pd.set_option("display.precision", 2)
 pd.set_option("display.float_format", lambda x: "%.2f" % x)
@@ -248,7 +248,7 @@ class LazyClassifier:
         self.custom_metric = custom_metric
         self.predictions = predictions
         self.models = {}
-        self.random_state = random_state or get_sklearn_random_state()
+        self.random_state = random_state or get_global_seed()
         self.classifiers = classifiers
 
     def fit(self, X_train, X_test, y_train, y_test):
@@ -492,7 +492,7 @@ class LazyRegressor:
         self.custom_metric = custom_metric
         self.predictions = predictions
         self.models = {}
-        self.random_state = random_state or get_sklearn_random_state()
+        self.random_state = random_state or get_global_seed()
         self.regressors = regressors
 
     def fit(self, X_train, X_test, y_train, y_test):

--- a/src/protify/probes/scikit_classes.py
+++ b/src/protify/probes/scikit_classes.py
@@ -12,7 +12,7 @@ from .lazy_predict import (
     ALL_MODEL_DICT
 )
 from .scikit_hypers import HYPERPARAMETER_DISTRIBUTIONS
-from ..seed_utils import get_sklearn_random_state
+from seed_utils import get_sklearn_random_state
 
 
 class ScikitArguments:

--- a/src/protify/probes/scikit_classes.py
+++ b/src/protify/probes/scikit_classes.py
@@ -12,6 +12,7 @@ from .lazy_predict import (
     ALL_MODEL_DICT
 )
 from .scikit_hypers import HYPERPARAMETER_DISTRIBUTIONS
+from ..seed_utils import get_sklearn_random_state
 
 
 class ScikitArguments:
@@ -23,7 +24,7 @@ class ScikitArguments:
         # Tuning arguments
         n_iter: int = 100,
         cv: int = 3,
-        random_state: int = 42,
+        random_state: Optional[int] = None,
         # Specific model arguments (optional)
         model_name: Optional[str] = None,
         model_args: Optional[Dict[str, Any]] = None,
@@ -33,7 +34,7 @@ class ScikitArguments:
         # Tuning arguments
         self.n_iter = n_iter
         self.cv = cv
-        self.random_state = random_state
+        self.random_state = random_state or get_sklearn_random_state()
         
         # Specific model arguments
         self.model_name = model_name

--- a/src/protify/probes/scikit_classes.py
+++ b/src/protify/probes/scikit_classes.py
@@ -3,7 +3,9 @@ import pandas as pd
 from sklearn.model_selection import RandomizedSearchCV
 from typing import Dict, Any, Tuple, Optional
 from metrics import get_regression_scorer, get_classification_scorer, classification_scorer, regression_scorer
+
 from utils import print_message
+from seed_utils import get_global_seed
 from .lazy_predict import (
     LazyRegressor,
     LazyClassifier,
@@ -12,7 +14,6 @@ from .lazy_predict import (
     ALL_MODEL_DICT
 )
 from .scikit_hypers import HYPERPARAMETER_DISTRIBUTIONS
-from seed_utils import get_sklearn_random_state
 
 
 class ScikitArguments:
@@ -34,7 +35,7 @@ class ScikitArguments:
         # Tuning arguments
         self.n_iter = n_iter
         self.cv = cv
-        self.random_state = random_state or get_sklearn_random_state()
+        self.random_state = random_state or get_global_seed()
         
         # Specific model arguments
         self.model_name = model_name

--- a/src/protify/seed_utils.py
+++ b/src/protify/seed_utils.py
@@ -124,9 +124,8 @@ def set_global_seed(seed: Optional[int] = None,
         if hasattr(torch, 'use_deterministic_algorithms'):
             try:
                 torch.use_deterministic_algorithms(True, warn_only=False)
-            except:
-                pass
-                print('torch.use_deterministic_algorithms is not available')
+            except Exception as e:
+                print(f'torch.use_deterministic_algorithms is not available: {e}')
     
     if logger:
         logger.info(f"Global random seed set to: {seed}")

--- a/src/protify/seed_utils.py
+++ b/src/protify/seed_utils.py
@@ -59,11 +59,11 @@ def set_cublas_workspace_config(logger: Optional[logging.Logger] = None):
         if logger:
             logger.warning(f"Could not detect GPU memory, using fallback config: {e}")
 
-def seed_worker(_worker_id: int):
+def seed_worker(worker_id: int):
     """Use with torch.utils.data.DataLoader(worker_init_fn=seed_worker) to sync NumPy/random per-worker."""
-    wseed = torch.initial_seed() % 2**32
-    np.random.seed(wseed)
-    random.seed(wseed)
+    worker_seed = torch.initial_seed() % 2**32
+    np.random.seed(worker_seed)
+    random.seed(worker_seed)
 
 def dataloader_generator(seed: int) -> "torch.Generator":
     """

--- a/src/protify/seed_utils.py
+++ b/src/protify/seed_utils.py
@@ -1,0 +1,153 @@
+"""
+Global seed management utilities for reproducible experiments.
+
+This module provides a centralized way to set random seeds across all
+random number generators used in the platform (torch, numpy, scikit-learn, random).
+"""
+
+import os
+import time
+import random
+import numpy as np
+import torch
+import logging
+from typing import Optional
+
+# Global variable to store the current seed
+_GLOBAL_SEED: Optional[int] = None
+
+
+def get_global_seed() -> Optional[int]:
+    """
+    Get the currently set global seed.
+    
+    Returns:
+        The current global seed value, or None if not set.
+    """
+    return _GLOBAL_SEED
+
+def set_cublas_workspace_config(logger: Optional[logging.Logger] = None):
+    """Set CUBLAS workspace config based on available GPU memory.
+
+    Required for CUDA >= 10.2, otherwise torch.use_deterministic_algorithms will throw an error.
+    """
+    try:
+        if torch.cuda.is_available():
+            # Get total GPU memory in GB
+            gpu_memory_gb = torch.cuda.get_device_properties(0).total_memory / (1024**3)
+            # Determine workspace size based on GPU memory
+            if gpu_memory_gb >= 40:  
+                workspace_config = ":4096:8"
+            elif gpu_memory_gb >= 20:  
+                workspace_config = ":2048:8"  
+            elif gpu_memory_gb >= 10:  
+                workspace_config = ":1024:8"
+            else:  
+                workspace_config = ":512:8"
+                
+            os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", workspace_config)
+            if logger:
+                logger.info(f"Set CUBLAS workspace config to {workspace_config} (GPU: {gpu_memory_gb:.1f}GB)")
+        else:
+            # CPU only, set a minimal workspace config
+            os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":16:8")
+            if logger:
+                logger.info("Set minimal CUBLAS workspace config for CPU")
+                
+    except Exception as e:
+        os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":16:8")
+        if logger:
+            logger.warning(f"Could not detect GPU memory, using fallback config: {e}")
+
+def seed_worker(_worker_id: int):
+    """Use with torch.utils.data.DataLoader(worker_init_fn=seed_worker) to sync NumPy/random per-worker."""
+    wseed = torch.initial_seed() % 2**32
+    np.random.seed(wseed)
+    random.seed(wseed)
+
+def dataloader_generator(seed: int) -> "torch.Generator":
+    """
+    Use with torch.utils.data.DataLoader(generator=dataloader_generator(seed)) to sync NumPy/random per-worker.
+    """
+    g = torch.Generator()
+    g.manual_seed(seed)
+    return g
+
+def set_global_seed(seed: Optional[int] = None,
+                    logger: Optional[logging.Logger] = None,
+                    deterministic: bool = False
+                    ) -> int:
+    """
+    Set the global random seed for all random number generators.
+    
+    This function sets seeds for:
+    - Python's random module
+    - NumPy
+    - PyTorch
+    
+    Args:
+        seed: The seed value to use. If None, uses current timestamp.
+        logger: Optional logger to log the seed value.
+    
+    Returns:
+        The seed value that was set.
+    """
+    global _GLOBAL_SEED
+    
+    # Generate seed from current time if not provided
+    if seed is None:
+        seed = int(time.time() * 1000000) % (2**31)
+    
+    # Store the global seed
+    _GLOBAL_SEED = seed
+    
+    random.seed(seed)
+    np.random.seed(seed)
+    
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)  # For multi-GPU setups
+        
+    if deterministic:
+        # Set deterministic behavior for reproducibility
+        # Note: This can significantly slow down operations. Only use if you need to be 100% reproducible
+        
+        # cuBLAS-based operations
+        set_cublas_workspace_config(logger)
+        # cuDNN-based operations
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+        torch.backends.cudnn.allow_tf32 = False
+        # CUDA/cuBLAS-based operations
+        torch.backends.cuda.matmul.allow_tf32 = False
+
+        if hasattr(torch, 'use_deterministic_algorithms'):
+            try:
+                torch.use_deterministic_algorithms(True, warn_only=False)
+            except:
+                pass
+                print('torch.use_deterministic_algorithms is not available')
+    
+    if logger:
+        logger.info(f"Global random seed set to: {seed}")
+        logger.info(f"Deterministic: {deterministic}")
+        logger.info(f"Use TF32: {torch.backends.cuda.matmul.allow_tf32}")
+        logger.info(f"cuDNN Benchmark: {torch.backends.cudnn.benchmark}")
+        logger.info(f"cuDNN Allow TF32: {torch.backends.cudnn.allow_tf32}")
+        logger.info(f"cuBLAS Workspace Config: {os.environ.get('CUBLAS_WORKSPACE_CONFIG')}")
+    return seed
+
+
+def get_sklearn_random_state(use_global: bool = True) -> Optional[int]:
+    """
+    Get a random state value suitable for scikit-learn models.
+    
+    Args:
+        use_global: If True, returns the global seed. If False, returns None.
+    
+    Returns:
+        The seed value to use for scikit-learn's random_state parameter.
+    """
+    if use_global and _GLOBAL_SEED is not None:
+        return _GLOBAL_SEED
+    return None

--- a/src/protify/seed_utils.py
+++ b/src/protify/seed_utils.py
@@ -9,8 +9,6 @@ import os
 import time
 import random
 import numpy as np
-import torch
-import logging
 from typing import Optional
 
 # Global variable to store the current seed
@@ -26,57 +24,38 @@ def get_global_seed() -> Optional[int]:
     """
     return _GLOBAL_SEED
 
-def set_cublas_workspace_config(logger: Optional[logging.Logger] = None):
-    """Set CUBLAS workspace config based on available GPU memory.
 
-    Required for CUDA >= 10.2, otherwise torch.use_deterministic_algorithms will throw an error.
+def set_cublas_workspace_config():
+    """Set CUBLAS workspace config to an allowed deterministic value.
+
+    Must be set BEFORE importing torch. Valid values (per NVIDIA docs):
+      - ":4096:8" (recommended)
+      - ":16:8"   (minimal workspace)
     """
-    try:
-        if torch.cuda.is_available():
-            # Get total GPU memory in GB
-            gpu_memory_gb = torch.cuda.get_device_properties(0).total_memory / (1024**3)
-            # Determine workspace size based on GPU memory
-            if gpu_memory_gb >= 40:  
-                workspace_config = ":4096:8"
-            elif gpu_memory_gb >= 20:  
-                workspace_config = ":2048:8"  
-            elif gpu_memory_gb >= 10:  
-                workspace_config = ":1024:8"
-            else:  
-                workspace_config = ":512:8"
-                
-            os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", workspace_config)
-            if logger:
-                logger.info(f"Set CUBLAS workspace config to {workspace_config} (GPU: {gpu_memory_gb:.1f}GB)")
-        else:
-            # CPU only, set a minimal workspace config
-            os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":16:8")
-            if logger:
-                logger.info("Set minimal CUBLAS workspace config for CPU")
-                
-    except Exception as e:
-        os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":16:8")
-        if logger:
-            logger.warning(f"Could not detect GPU memory, using fallback config: {e}")
+    # Only set if not already provided by the environment/user
+    if "CUBLAS_WORKSPACE_CONFIG" not in os.environ:
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+
 
 def seed_worker(worker_id: int):
     """Use with torch.utils.data.DataLoader(worker_init_fn=seed_worker) to sync NumPy/random per-worker."""
+    import torch
     worker_seed = torch.initial_seed() % 2**32
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 
-def dataloader_generator(seed: int) -> "torch.Generator":
+
+def dataloader_generator(seed: int):
     """
     Use with torch.utils.data.DataLoader(generator=dataloader_generator(seed)) to sync NumPy/random per-worker.
     """
+    import torch
     g = torch.Generator()
     g.manual_seed(seed)
     return g
 
-def set_global_seed(seed: Optional[int] = None,
-                    logger: Optional[logging.Logger] = None,
-                    deterministic: bool = False
-                    ) -> int:
+
+def set_global_seed(seed: Optional[int] = None) -> int:
     """
     Set the global random seed for all random number generators.
     
@@ -87,66 +66,49 @@ def set_global_seed(seed: Optional[int] = None,
     
     Args:
         seed: The seed value to use. If None, uses current timestamp.
-        logger: Optional logger to log the seed value.
     
     Returns:
         The seed value that was set.
-    """
-    global _GLOBAL_SEED
-    
+    """    
     # Generate seed from current time if not provided
     if seed is None:
         seed = int(time.time() * 1000000) % (2**31)
     
     # Store the global seed
+    global _GLOBAL_SEED
     _GLOBAL_SEED = seed
     
     random.seed(seed)
     np.random.seed(seed)
-    
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)  # For multi-GPU setups
-        
-    if deterministic:
-        # Set deterministic behavior for reproducibility
-        # Note: This can significantly slow down operations. Only use if you need to be 100% reproducible
-        
-        # cuBLAS-based operations
-        set_cublas_workspace_config(logger)
-        # cuDNN-based operations
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
-        torch.backends.cudnn.allow_tf32 = False
-        # CUDA/cuBLAS-based operations
-        torch.backends.cuda.matmul.allow_tf32 = False
 
-        if hasattr(torch, 'use_deterministic_algorithms'):
-            try:
-                torch.use_deterministic_algorithms(True, warn_only=False)
-            except Exception as e:
-                print(f'torch.use_deterministic_algorithms is not available: {e}')
-    
-    if logger:
-        logger.info(f"Global random seed set to: {seed}")
-        logger.info(f"Deterministic: {deterministic}")
-        logger.info(f"Use TF32: {torch.backends.cuda.matmul.allow_tf32}")
-        logger.info(f"cuDNN Benchmark: {torch.backends.cudnn.benchmark}")
-        logger.info(f"cuDNN Allow TF32: {torch.backends.cudnn.allow_tf32}")
-        logger.info(f"cuBLAS Workspace Config: {os.environ.get('CUBLAS_WORKSPACE_CONFIG')}")
+    # Import torch lazily to avoid initializing CUDA before env is set elsewhere
+    import torch
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)  # For multi-GPU setups
     return seed
 
 
-def get_sklearn_random_state(use_global: bool = True) -> Optional[int]:
-    """
-    Get a random state value suitable for scikit-learn models.
-    
-    Args:
-        use_global: If True, returns the global seed. If False, returns None.
-    
-    Returns:
-        The seed value to use for scikit-learn's random_state parameter.
-    """
-    if use_global and _GLOBAL_SEED is not None:
-        return _GLOBAL_SEED
-    return None
+def set_determinism():
+    # set_cublas_workspace_config() must happen BEFORE importing torch
+    set_cublas_workspace_config()
+
+    # Import torch only after the env var has been set
+    import torch
+
+    # Set deterministic behavior for reproducibility
+    # Note: This can significantly slow down operations. Only use if you need to be 100% reproducible
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    torch.backends.cudnn.allow_tf32 = False
+    torch.backends.cuda.matmul.allow_tf32 = False
+
+    if hasattr(torch, 'use_deterministic_algorithms'):
+        try:
+            torch.use_deterministic_algorithms(True, warn_only=False)
+        except Exception as e:
+            print(f'torch.use_deterministic_algorithms is not available: {e}')
+            # print torch version
+            print(f'torch version: {torch.__version__}')
+            print('Make sure you are using the correct version of torch')

--- a/src/protify/visualization/reduce_dim.py
+++ b/src/protify/visualization/reduce_dim.py
@@ -9,6 +9,7 @@ from sklearn.manifold import TSNE as SklearnTSNE
 from typing import Optional, Union, List
 from matplotlib.colors import LinearSegmentedColormap
 from utils import torch_load, print_message
+from ..seed_utils import get_sklearn_random_state
 
 
 @dataclass
@@ -167,7 +168,7 @@ class DimensionalityReducer:
 class PCA(DimensionalityReducer):
     def __init__(self, args: VisualizationArguments):
         super().__init__(args)
-        self.pca = SklearnPCA(n_components=args.n_components, random_state=args.seed)
+        self.pca = SklearnPCA(n_components=args.n_components, random_state=get_sklearn_random_state() or args.seed)
         
     def fit_transform(self):
         return self.pca.fit_transform(self.embeddings)
@@ -179,7 +180,7 @@ class TSNE(DimensionalityReducer):
         self.tsne = SklearnTSNE(
             n_components=self.args.n_components,
             perplexity=self.args.perplexity,
-            random_state=self.args.seed
+            random_state=get_sklearn_random_state() or self.args.seed
         )
         
     def fit_transform(self):
@@ -193,7 +194,7 @@ class UMAP(DimensionalityReducer):
             n_components=self.args.n_components,
             n_neighbors=self.args.n_neighbors,
             min_dist=self.args.min_dist,
-            random_state=self.args.seed
+            random_state=get_sklearn_random_state() or self.args.seed
         )
         
     def fit_transform(self):

--- a/src/protify/visualization/reduce_dim.py
+++ b/src/protify/visualization/reduce_dim.py
@@ -8,8 +8,9 @@ from sklearn.decomposition import PCA as SklearnPCA
 from sklearn.manifold import TSNE as SklearnTSNE
 from typing import Optional, Union, List
 from matplotlib.colors import LinearSegmentedColormap
+
 from utils import torch_load, print_message
-from ..seed_utils import get_sklearn_random_state
+from seed_utils import get_global_seed
 
 
 @dataclass
@@ -168,7 +169,7 @@ class DimensionalityReducer:
 class PCA(DimensionalityReducer):
     def __init__(self, args: VisualizationArguments):
         super().__init__(args)
-        self.pca = SklearnPCA(n_components=args.n_components, random_state=get_sklearn_random_state() or args.seed)
+        self.pca = SklearnPCA(n_components=args.n_components, random_state=get_global_seed() or args.seed)
         
     def fit_transform(self):
         return self.pca.fit_transform(self.embeddings)
@@ -180,7 +181,7 @@ class TSNE(DimensionalityReducer):
         self.tsne = SklearnTSNE(
             n_components=self.args.n_components,
             perplexity=self.args.perplexity,
-            random_state=get_sklearn_random_state() or self.args.seed
+            random_state=get_global_seed() or self.args.seed
         )
         
     def fit_transform(self):
@@ -194,7 +195,7 @@ class UMAP(DimensionalityReducer):
             n_components=self.args.n_components,
             n_neighbors=self.args.n_neighbors,
             min_dist=self.args.min_dist,
-            random_state=get_sklearn_random_state() or self.args.seed
+            random_state=get_global_seed() or self.args.seed
         )
         
     def fit_transform(self):

--- a/src/protify/yamls/base.yaml
+++ b/src/protify/yamls/base.yaml
@@ -5,6 +5,10 @@ synthyra_api_key: null
 wandb_api_key: null
 
 
+# Random seeds
+seed: !!int 42
+deterministic: !!bool false
+
 # Paths
 yaml_path: null
 log_dir: logs

--- a/src/protify/yamls/base.yaml
+++ b/src/protify/yamls/base.yaml
@@ -88,6 +88,5 @@ base_grad_accum: !!int 8
 lr: !!float 1e-4
 weight_decay: !!float 0.00
 patience: !!int 1
-seed: !!int 42
 full_finetuning: !!bool false
 hybrid_probe: !!bool false


### PR DESCRIPTION
Created a new file, seed_utils.py, with various functions for setting a centralized seed and adding deterministic capabilities to promote reproducible experiments across the platform.

In main.py:
- added a new CLI flag `--deterministic` (default = False). When specified it promotes using deterministic processes at the cost of slower training times.
- Modified `--seed` to default to None. Instead, set_global_seed() sets the seed based on the current time
- set_global_seed() is now the first operation after parsing args
- Applied seeding for LogReplayer

In embedder.py, integrated deterministic DataLoader seeding per PyTorch [docs](https://docs.pytorch.org/docs/stable/notes/randomness.html#reproducibility) advice.

In data_mixin.py passed the seed when train_test_split is called