### PR TITLE
Weights & Biases Hyperparameter Optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ src/protify/private_yamls
 *.db
 *.yaml
 !yamls/base.yaml
+!yamls/sweep_full.yaml
+!yamls/sweep_probe.yaml
+!yamls/sweep_transformer_probe.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ lightgbm
 pyfiglet
 seaborn>=0.13.2
 matplotlib>=3.9.0
+wandb

--- a/src/protify/hyperopt_utils.py
+++ b/src/protify/hyperopt_utils.py
@@ -1,0 +1,159 @@
+"""
+Utility functions for hyperparameter optimization in Protify.
+"""
+
+import copy
+import json
+import wandb
+from typing import Dict, Any, List, Tuple
+
+
+def select_metric(metrics: Dict[str, Any], sweep_metric: str) -> float:
+    """
+    Function to select the metric to optimize
+    """
+    if metrics is None:
+        raise ValueError("Metrics are None")
+    
+    if sweep_metric in metrics and metrics[sweep_metric] is not None:
+        try:
+            return float(metrics[sweep_metric])
+        except Exception as e:
+            raise ValueError(f"Error converting {sweep_metric} to float: {e}")
+
+def apply_config(cfg: Dict[str, Any], probe_args: Any, trainer_args: Any, 
+                probe_keys: set, trainer_keys: set) -> None:
+    """
+    Function to apply config values to probe and trainer arguments
+    """
+    for k, v in cfg.items():
+        if k in probe_keys and hasattr(probe_args, k):
+            setattr(probe_args, k, v)
+        if k in trainer_keys and hasattr(trainer_args, k):
+            setattr(trainer_args, k, v)
+
+
+def create_objective_function(model_name: str, data_name: str, dataset: Tuple, 
+                            base_probe: Dict[str, Any], base_trainer: Dict[str, Any],
+                            probe_args: Any, trainer_args: Any, full_args: Any,
+                            sweep_config: Dict[str, Any], probe_keys: set, trainer_keys: set,
+                            emb_dict: Any, ppi: bool, random_id: str, model: Any,
+                            get_base_model_for_training, get_probe, wrap_lora,
+                            trainer_base_model, trainer_hybrid_model, trainer_probe):
+    """
+    Create and return the objective function for hyperparameter optimization.
+    
+    Args:
+        model_name: Name of the model
+        data_name: Name of the dataset
+        dataset: Tuple containing train, valid, test sets and metadata
+        base_probe: Base probe arguments
+        base_trainer: Base trainer arguments
+        probe_args: Probe arguments object
+        trainer_args: Trainer arguments object
+        full_args: Full arguments object
+        sweep_config: Sweep configuration
+        probe_keys: Set of valid probe configuration keys
+        trainer_keys: Set of valid trainer configuration keys
+        emb_dict: Embedding dictionary
+        ppi: Whether this is a PPI task
+        random_id: Random identifier for logging
+        get_base_model_for_training: Function to get base model for training
+        get_probe: Function to get probe
+        wrap_lora: Function to wrap model with LoRA
+        trainer_base_model: Function to train base model
+        trainer_hybrid_model: Function to train hybrid model
+        trainer_probe: Function to train probe
+        
+    Returns:
+        function: The objective function for hyperparameter optimization
+    """
+    train_set, valid_set, test_set, num_labels, label_type, ppi = dataset
+    
+    def objective():
+        # New run
+        run = wandb.init(project=full_args.wandb_project,
+                          entity=full_args.wandb_entity,
+                          config=sweep_config,
+                          reinit=True,
+                          tags=["sweep", f"model:{model_name}", f"data:{data_name}"],
+        )
+        run.name = f"sweep-{model_name}_{data_name}-{run.id[:6]}"
+        run.save()
+        try:
+            # Reset to base then apply config
+            probe_args.__dict__.update(copy.deepcopy(base_probe))
+            trainer_args.__dict__.update(copy.deepcopy(base_trainer))
+            trainer_args.make_plots = False
+            trainer_args.sweep_mode = True
+            
+            cfg = dict(wandb.config)
+            apply_config(cfg, probe_args, trainer_args, probe_keys, trainer_keys)
+
+            if full_args.full_finetuning:
+                _, valid_metrics, test_metrics = trainer_base_model(
+                    model, 
+                    tokenizer=get_base_model_for_training(model_name,
+                                                          tokenwise=probe_args.tokenwise, 
+                                                          num_labels=probe_args.num_labels, 
+                                                          hybrid=False),
+                    model_name=model_name,
+                    data_name=data_name,
+                    train_dataset=train_set,
+                    valid_dataset=valid_set,
+                    test_dataset=test_set,
+                    ppi=ppi,
+                    log_id=random_id,
+                )
+            elif full_args.hybrid_probe:
+                model, tokenizer = get_base_model_for_training(model_name, 
+                                                                tokenwise=probe_args.tokenwise, 
+                                                                num_labels=probe_args.num_labels, 
+                                                                hybrid=True)
+                if probe_args.lora:
+                    model = wrap_lora(model, probe_args.lora_r, probe_args.lora_alpha, probe_args.lora_dropout)
+                probe = get_probe(probe_args)
+                _, valid_metrics, test_metrics = trainer_hybrid_model(
+                    model=model,
+                    tokenizer=tokenizer,
+                    probe=probe,
+                    model_name=model_name,
+                    data_name=data_name,
+                    train_dataset=train_set,
+                    valid_dataset=valid_set,
+                    test_dataset=test_set,
+                    emb_dict=emb_dict,
+                    ppi=ppi,
+                    log_id=random_id,
+                )
+            else:
+                probe = get_probe(probe_args)
+                _, valid_metrics, test_metrics = trainer_probe(
+                    model=probe,
+                    tokenizer=tokenizer,
+                    model_name=model_name,
+                    data_name=data_name,
+                    train_dataset=train_set,
+                    valid_dataset=valid_set,
+                    test_dataset=test_set,
+                    emb_dict=emb_dict,
+                    ppi=ppi,
+                    log_id=random_id,
+                )
+
+            # Log to wandb
+            all_metrics = {}
+            if isinstance(valid_metrics, dict):
+                for k, v in valid_metrics.items():
+                    all_metrics[f"valid_{k}"] = v
+            if isinstance(test_metrics, dict):
+                for k, v in test_metrics.items():
+                    all_metrics[f"test_{k}"] = v
+            wandb.log(all_metrics)
+
+            metric_value = select_metric(valid_metrics, full_args.sweep_metric)
+            return metric_value
+        finally:
+            run.finish()
+    
+    return objective

--- a/src/protify/hyperopt_utils.py
+++ b/src/protify/hyperopt_utils.py
@@ -71,31 +71,36 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
     train_set, valid_set, test_set, num_labels, label_type, ppi = dataset
     
     def objective():
-        # New run
-        run = wandb.init(project=full_args.wandb_project,
-                          entity=full_args.wandb_entity,
-                          config=sweep_config,
-                          reinit=True,
-                          tags=["sweep", f"model:{model_name}", f"data:{data_name}"],
+        run = wandb.init(
+            project=full_args.wandb_project,
+            entity=full_args.wandb_entity,
+            config=sweep_config,
+            reinit=True,
+            tags=["sweep", f"model:{model_name}", f"data:{data_name}"],
         )
         run.name = f"sweep-{model_name}_{data_name}-{run.id[:6]}"
         try:
-            # Reset to base then apply config
+            # Reset args, apply sweep cfg
             probe_args.__dict__.update(copy.deepcopy(base_probe))
             trainer_args.__dict__.update(copy.deepcopy(base_trainer))
             trainer_args.make_plots = False
             trainer_args.sweep_mode = True
-            
+
             cfg = dict(wandb.config)
             apply_config(cfg, probe_args, trainer_args, probe_keys, trainer_keys)
 
             if full_args.full_finetuning:
+                model, tokenizer = get_base_model_for_training(
+                    model_name,
+                    tokenwise=probe_args.tokenwise,
+                    num_labels=probe_args.num_labels,
+                    hybrid=False,
+                )
+                if probe_args.lora:
+                    model = wrap_lora(model, probe_args.lora_r, probe_args.lora_alpha, probe_args.lora_dropout)
                 _, valid_metrics, test_metrics = trainer_base_model(
-                    model, 
-                    tokenizer=get_base_model_for_training(model_name,
-                                                          tokenwise=probe_args.tokenwise, 
-                                                          num_labels=probe_args.num_labels, 
-                                                          hybrid=False),
+                    model,
+                    tokenizer=tokenizer,
                     model_name=model_name,
                     data_name=data_name,
                     train_dataset=train_set,
@@ -104,11 +109,14 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
                     ppi=ppi,
                     log_id=random_id,
                 )
+
             elif full_args.hybrid_probe:
-                model, tokenizer = get_base_model_for_training(model_name, 
-                                                                tokenwise=probe_args.tokenwise, 
-                                                                num_labels=probe_args.num_labels, 
-                                                                hybrid=True)
+                model, tokenizer = get_base_model_for_training(
+                    model_name,
+                    tokenwise=probe_args.tokenwise,
+                    num_labels=probe_args.num_labels,
+                    hybrid=True,
+                )
                 if probe_args.lora:
                     model = wrap_lora(model, probe_args.lora_r, probe_args.lora_alpha, probe_args.lora_dropout)
                 probe = get_probe(probe_args)
@@ -125,7 +133,15 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
                     ppi=ppi,
                     log_id=random_id,
                 )
-            else:
+
+            else:  # pure probe
+                # You still need a tokenizer for the trainer
+                _, tokenizer = get_base_model_for_training(
+                    model_name,
+                    tokenwise=probe_args.tokenwise,
+                    num_labels=probe_args.num_labels,
+                    hybrid=False,
+                )
                 probe = get_probe(probe_args)
                 _, valid_metrics, test_metrics = trainer_probe(
                     model=probe,
@@ -140,7 +156,7 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
                     log_id=random_id,
                 )
 
-            # Log to wandb
+            # Log & return sweep metric
             all_metrics = {}
             if isinstance(valid_metrics, dict):
                 for k, v in valid_metrics.items():
@@ -151,7 +167,7 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
             wandb.log(all_metrics)
 
             metric_value = select_metric(valid_metrics, full_args.sweep_metric)
-            return metric_value
+            return float(metric_value)
         finally:
             run.finish()
     

--- a/src/protify/hyperopt_utils.py
+++ b/src/protify/hyperopt_utils.py
@@ -37,7 +37,7 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
                             base_probe: Dict[str, Any], base_trainer: Dict[str, Any],
                             probe_args: Any, trainer_args: Any, full_args: Any,
                             sweep_config: Dict[str, Any], probe_keys: set, trainer_keys: set,
-                            emb_dict: Any, ppi: bool, random_id: str, model: Any,
+                            emb_dict: Any, ppi: bool, random_id: str,
                             get_base_model_for_training, get_probe, wrap_lora,
                             trainer_base_model, trainer_hybrid_model, trainer_probe):
     """

--- a/src/protify/hyperopt_utils.py
+++ b/src/protify/hyperopt_utils.py
@@ -79,7 +79,6 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
                           tags=["sweep", f"model:{model_name}", f"data:{data_name}"],
         )
         run.name = f"sweep-{model_name}_{data_name}-{run.id[:6]}"
-        run.save()
         try:
             # Reset to base then apply config
             probe_args.__dict__.update(copy.deepcopy(base_probe))

--- a/src/protify/hyperopt_utils.py
+++ b/src/protify/hyperopt_utils.py
@@ -37,7 +37,7 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
                             base_probe: Dict[str, Any], base_trainer: Dict[str, Any],
                             probe_args: Any, trainer_args: Any, full_args: Any,
                             sweep_config: Dict[str, Any], probe_keys: set, trainer_keys: set,
-                            emb_dict: Any, ppi: bool, random_id: str,
+                            emb_dict: Any, ppi: bool, random_id: str, results_list: List[Dict[str, Any]],
                             get_base_model_for_training, get_probe, wrap_lora,
                             trainer_base_model, trainer_hybrid_model, trainer_probe):
     """
@@ -57,6 +57,7 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
         trainer_keys: Set of valid trainer configuration keys
         emb_dict: Embedding dictionary
         ppi: Whether this is a PPI task
+        results_list: List to store results
         random_id: Random identifier for logging
         get_base_model_for_training: Function to get base model for training
         get_probe: Function to get probe
@@ -160,13 +161,20 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
             all_metrics = {}
             if isinstance(valid_metrics, dict):
                 for k, v in valid_metrics.items():
-                    all_metrics[f"valid_{k}"] = v
+                    all_metrics[f"{k}"] = v
             if isinstance(test_metrics, dict):
                 for k, v in test_metrics.items():
-                    all_metrics[f"test_{k}"] = v
+                    all_metrics[f"{k}"] = v
             wandb.log(all_metrics)
 
             metric_value = select_metric(valid_metrics, full_args.sweep_metric)
+            results_list.append({
+                "wandb_id": run.id,
+                "selected_metric": float(metric_value),
+                "config": dict(run.config),
+                "valid_metrics": valid_metrics,
+                "test_metrics": test_metrics,
+            })
             return float(metric_value)
         finally:
             run.finish()

--- a/src/protify/hyperopt_utils.py
+++ b/src/protify/hyperopt_utils.py
@@ -169,7 +169,7 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
 
             metric_value = select_metric(valid_metrics, full_args.sweep_metric)
             results_list.append({
-                "wandb_id": run.id,
+                "wandb_run_id": run.id,
                 "selected_metric": float(metric_value),
                 "config": dict(run.config),
                 "valid_metrics": valid_metrics,

--- a/src/protify/hyperopt_utils.py
+++ b/src/protify/hyperopt_utils.py
@@ -24,7 +24,7 @@ def select_metric(metrics: Dict[str, Any], sweep_metric: str) -> float:
 def apply_config(cfg: Dict[str, Any], probe_args: Any, trainer_args: Any, 
                 probe_keys: set, trainer_keys: set) -> None:
     """
-    Function to apply config values to probe and trainer arguments
+    Function to apply sweep config values to probe and trainer arguments
     """
     for k, v in cfg.items():
         if k in probe_keys and hasattr(probe_args, k):
@@ -135,8 +135,7 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
                     log_id=random_id,
                 )
 
-            else:  # pure probe
-                # You still need a tokenizer for the trainer
+            else:  # nn probe
                 _, tokenizer = get_base_model_for_training(
                     model_name,
                     tokenwise=probe_args.tokenwise,
@@ -166,11 +165,10 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
                 for k, v in test_metrics.items():
                     all_metrics[f"{k}"] = v
             wandb.log(all_metrics)
-
             metric_value = select_metric(valid_metrics, full_args.sweep_metric)
             results_list.append({
                 "wandb_run_id": run.id,
-                "selected_metric": float(metric_value),
+                full_args.sweep_metric: metric_value,
                 "config": dict(run.config),
                 "valid_metrics": valid_metrics,
                 "test_metrics": test_metrics,
@@ -178,5 +176,4 @@ def create_objective_function(model_name: str, data_name: str, dataset: Tuple,
             return float(metric_value)
         finally:
             run.finish()
-    
     return objective

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -10,7 +10,7 @@ os.environ["TF_ENABLE_ONEDNN_OPTS"] = "0"
 os.environ["TOKENIZERS_PARALLELISM"] = "true"
 
 
-def parse_arguments():
+def parse_arguments():  
     parser = argparse.ArgumentParser(description="Script with arguments mirroring the provided YAML settings.")
     # ----------------- ID ----------------- #
     parser.add_argument("--hf_username", default="Synthyra", help="Hugging Face username.")

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -109,7 +109,7 @@ def parse_arguments():
     parser.add_argument("--use_wandb_hyperopt", action="store_true", default=False, help="Use Weights & Biases hyperparameter optimization.")
     parser.add_argument("--wandb_project", type=str, default="Protify", help="W&B project name for sweeps.")
     parser.add_argument("--wandb_entity", type=str, default=None, help="W&B entity (team/user) for sweeps.")
-    parser.add_argument("--sweep_config_path", type=str, default='yamls/sweep_config.yaml', help="Path to W&B sweep config YAML.")
+    parser.add_argument("--sweep_config_path", type=str, default=None, help="Path to W&B sweep config YAML. If not specified, will automatically choose sweep_full.yaml for full finetuning or sweep_probe.yaml for probe/hybrid.")
     parser.add_argument("--sweep_count", type=int, default=10, help="Number of hyperparameter trials to run in the sweep.")
     parser.add_argument("--sweep_method", type=str, default="bayes", choices=["bayes", "grid", "random"], help="Sweep method for hyperparameter optimization.")
     parser.add_argument("--sweep_metric", type=str, default="eval_loss", help="Metric to optimize during sweep.")
@@ -340,15 +340,24 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
         import json
         import wandb
         sweep_config = {}
-        if self.full_args.sweep_config_path is not None and os.path.exists(self.full_args.sweep_config_path):
-            with open(self.full_args.sweep_config_path, 'r') as f:
-                sweep_config = yaml.safe_load(f)
-
+        
         if self.full_args.full_finetuning:
-            params_to_hyperopt = sweep_config.get("parameters_full", {})
+            sweep_config_path = 'yamls/sweep_full.yaml'
         else:
-            # use probe settings for both probe and hybrid
-            params_to_hyperopt = sweep_config.get("parameters_probe", {})
+            sweep_config_path = 'yamls/sweep_probe.yaml'
+        
+        # Override with user-specified path if provided
+        if self.full_args.sweep_config_path is not None:
+            sweep_config_path = self.full_args.sweep_config_path
+            
+        if os.path.exists(sweep_config_path):
+            with open(sweep_config_path, 'r') as f:
+                sweep_config = yaml.safe_load(f)
+        else:
+            self.logger.warning(f"Sweep config file not found: {sweep_config_path}")
+
+        # Get parameters from the loaded sweep config
+        params_to_hyperopt = sweep_config.get("parameters", {})
 
         method = self.full_args.sweep_method
         metric = {"name": self.full_args.sweep_metric, "goal": self.full_args.sweep_goal}

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -112,8 +112,8 @@ def parse_arguments():
     parser.add_argument("--sweep_config_path", type=str, default='yamls/sweep_config.yaml', help="Path to W&B sweep config YAML.")
     parser.add_argument("--sweep_count", type=int, default=10, help="Number of hyperparameter trials to run in the sweep.")
     parser.add_argument("--sweep_method", type=str, default="bayes", choices=["bayes", "grid", "random"], help="Sweep method for hyperparameter optimization.")
-    parser.add_argument("--sweep_metric", type=str, default="mcc", help="Metric to optimize during sweep.")
-    parser.add_argument("--sweep_goal", type=str, default='maximize', choices=['maximize', 'minimize'], help="Goal for the sweep metric (maximize/minimize)")
+    parser.add_argument("--sweep_metric", type=str, default="eval_loss", help="Metric to optimize during sweep.")
+    parser.add_argument("--sweep_goal", type=str, default='minimize', choices=['maximize', 'minimize'], help="Goal for the sweep metric (maximize/minimize)")
     args = parser.parse_args()
 
     if args.hf_token is not None:
@@ -393,7 +393,7 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
                 base_probe = copy.deepcopy(self.probe_args.__dict__)
                 base_trainer = copy.deepcopy(self.trainer_args.__dict__)
                 model, tokenizer = get_base_model_for_training(model_name, tokenwise=self.probe_args.tokenwise, num_labels=self.probe_args.num_labels, hybrid=False)
-                    
+
                 objective = create_objective_function(
                     model_name=model_name,
                     data_name=data_name,

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -354,8 +354,6 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
         metric = {"name": self.full_args.sweep_metric, "goal": self.full_args.sweep_goal}
         early_term = sweep_config.get("early_terminate", None)
 
-        # select_metric function moved to hyperopt_utils.py
-
         # Keys allowed to be set from sweeps
         probe_keys = set(['hidden_size','dropout','n_layers','pre_ln','classifier_dim','transformer_dropout','classifier_dropout','n_heads','rotary','lora','lora_r','lora_alpha','lora_dropout','probe_type','tokenwise'])
         trainer_keys = set(['lr','weight_decay','num_epochs','probe_batch_size','base_batch_size','probe_grad_accum','base_grad_accum','patience','seed'])
@@ -394,10 +392,8 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
                 # Snapshot current args so we can restore after each trial
                 base_probe = copy.deepcopy(self.probe_args.__dict__)
                 base_trainer = copy.deepcopy(self.trainer_args.__dict__)
-
-                # apply_config function moved to hyperopt_utils.py
-
-                # Create objective function using hyperopt_utils
+                model, tokenizer = get_base_model_for_training(model_name, tokenwise=self.probe_args.tokenwise, num_labels=self.probe_args.num_labels, hybrid=False)
+                    
                 objective = create_objective_function(
                     model_name=model_name,
                     data_name=data_name,
@@ -674,7 +670,6 @@ def main(args: SimpleNamespace):
         main.write_results()
         main.generate_plots()
         main.end_log()
-
 
 if __name__ == "__main__":
     main(args)

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -402,6 +402,7 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
                 base_probe = copy.deepcopy(self.probe_args.__dict__)
                 base_trainer = copy.deepcopy(self.trainer_args.__dict__)
 
+                results_list = []
                 objective = create_objective_function(
                     model_name=model_name,
                     data_name=data_name,
@@ -417,12 +418,14 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
                     emb_dict=emb_dict,
                     ppi=ppi,
                     random_id=self.random_id,
+                    results_list=results_list,
                     get_base_model_for_training=get_base_model_for_training,
                     get_probe=get_probe,
                     wrap_lora=wrap_lora,
                     trainer_base_model=self.trainer_base_model,
                     trainer_hybrid_model=self.trainer_hybrid_model,
-                    trainer_probe=self.trainer_probe
+                    trainer_probe=self.trainer_probe,
+                    results_list=results_list,
                 )
                 wb_sweep = {
                     "method": method,

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -396,8 +396,6 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
                         input_dim = self.get_embedding_dim_pth(emb_dict, test_seq, tokenizer)
                     self.probe_args.input_dim = input_dim * 2 if (ppi and not self._full) else input_dim
 
-                results_list = []
-
                 # Snapshot current args so we can restore after each trial
                 base_probe = copy.deepcopy(self.probe_args.__dict__)
                 base_trainer = copy.deepcopy(self.trainer_args.__dict__)

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -2,7 +2,6 @@ import os
 import argparse
 import yaml
 from types import SimpleNamespace
-from hyperopt_utils import select_metric, apply_config, create_objective_function
 
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
@@ -185,6 +184,7 @@ from embedder import EmbeddingArguments, Embedder
 from logger import MetricsLogger, log_method_calls
 from utils import torch_load, print_message
 from visualization.plot_result import create_plots
+from hyperopt_utils import apply_config, create_objective_function
 
 
 class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
@@ -339,14 +339,18 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
         import copy
         import json
         import wandb
+        import csv
+
         sweep_config = {}
         
         if self.full_args.full_finetuning:
             sweep_config_path = 'yamls/sweep_full.yaml'
+        elif self.probe_args.probe_type == 'transformer':
+            sweep_config_path = 'yamls/sweep_transformer_probe.yaml'
         else:
             sweep_config_path = 'yamls/sweep_probe.yaml'
         
-        # Override with user-specified path if provided
+        # Override if path specified
         if self.full_args.sweep_config_path is not None:
             sweep_config_path = self.full_args.sweep_config_path
             
@@ -356,7 +360,6 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
         else:
             self.logger.warning(f"Sweep config file not found: {sweep_config_path}")
 
-        # Get parameters from the loaded sweep config
         params_to_hyperopt = sweep_config.get("parameters", {})
 
         method = self.full_args.sweep_method
@@ -371,20 +374,48 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
         self.logger.info(f"Hyperopt over {total_combinations} model/dataset combinations")
 
         for model_name in self.model_args.model_names:
-            # Prepare tokenizer and embeddings info if needed
             tokenizer = get_tokenizer(model_name)
             test_seq = self.all_seqs[0]
 
+            if model_name in ["Random", "Random-Transformer"]:
+                message = f"Skipping hyperparameter optimization for {model_name}."
+                self.logger.info(message)
+                print_message(message)
+
+                for data_name, dataset in self.datasets.items():
+                    self.logger.info(f"Obtaining results for {data_name} with {model_name}")
+                    train_set, valid_set, test_set, num_labels, label_type, ppi = dataset
+                    self.probe_args.num_labels = num_labels
+                    self.probe_args.task_type = label_type
+                    self.trainer_args.task_type = label_type
+                    self.trainer_args.make_plots = True
+
+                    emb_dict = None
+                    if not self.full_args.full_finetuning:
+                        if self._sql:
+                            save_path = os.path.join(self.embedding_args.embedding_save_dir, f'{model_name}_{self._full}.db')
+                            input_dim = self.get_embedding_dim_sql(save_path, test_seq, tokenizer)
+                        else:
+                            save_path = os.path.join(self.embedding_args.embedding_save_dir, f'{model_name}_{self._full}.pth')
+                            emb_dict = torch_load(save_path)
+                            input_dim = self.get_embedding_dim_pth(emb_dict, test_seq, tokenizer)
+                        self.probe_args.input_dim = input_dim * 2 if (ppi and not self._full) else input_dim
+                    if self.full_args.full_finetuning:
+                        _ = self._run_full_finetuning(model_name, data_name, train_set, valid_set, test_set, ppi, sweep_mode=False)
+                    elif self.full_args.hybrid_probe:
+                        _ = self._run_hybrid_probe(model_name, data_name, train_set, valid_set, test_set, tokenizer, emb_dict=emb_dict, ppi=ppi, sweep_mode=False)
+                    else:
+                        _ = self._run_nn_probe(model_name, data_name, train_set, valid_set, test_set, tokenizer, emb_dict=emb_dict, ppi=ppi, sweep_mode=False)
+                continue
+
             for data_name, dataset in self.datasets.items():
                 self.logger.info(f"Starting W&B sweep for {data_name} with {model_name}")
+                print_message(f"Starting W&B sweep for {data_name} with {model_name}")
                 train_set, valid_set, test_set, num_labels, label_type, ppi = dataset
-
-                # Update task-specific settings
                 self.probe_args.num_labels = num_labels
                 self.probe_args.task_type = label_type
                 self.trainer_args.task_type = label_type
 
-                # Determine input dim and embedding dict if needed
                 emb_dict = None
                 if not self.full_args.full_finetuning:
                     if self._sql:
@@ -396,7 +427,7 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
                         input_dim = self.get_embedding_dim_pth(emb_dict, test_seq, tokenizer)
                     self.probe_args.input_dim = input_dim * 2 if (ppi and not self._full) else input_dim
 
-                # Snapshot current args so we can restore after each trial
+                # Save base args for restoring after each trial
                 base_probe = copy.deepcopy(self.probe_args.__dict__)
                 base_trainer = copy.deepcopy(self.trainer_args.__dict__)
 
@@ -434,37 +465,48 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
                 wandb.agent(sweep_id, function=objective, count=self.full_args.sweep_count)
 
                 # Sort, write, and save sweep results
-                results_list.sort(key=lambda x: x['selected_metric'], reverse=True)
+                reverse_flag = True if self.full_args.sweep_goal == "maximize" else False
+                results_list.sort(key=lambda x: x[self.full_args.sweep_metric], reverse=reverse_flag)
                 sweep_log_path = os.path.join(self.full_args.log_dir, f"{self.random_id}_sweep_{data_name}_{model_name}.csv")
-                import csv as csv
                 with open(sweep_log_path, 'w', newline='', encoding='utf-8') as f:
                     writer = csv.writer(f, delimiter=',')
-                    # header
-                    header = ["rank","wandb_run_id","selected_metric","config","valid_metrics","test_metrics"]
-                    writer.writerow(header)
+                    # Columns
+                    columns = ["rank","wandb_run_id",self.full_args.sweep_metric,"config","valid_metrics","test_metrics"]
+                    writer.writerow(columns)
                     for idx, res in enumerate(results_list, start=1):
                         writer.writerow([
                             idx,
                             res['wandb_run_id'],
-                            res['selected_metric'],
+                            res[self.full_args.sweep_metric],
                             json.dumps(res['config']),
                             json.dumps(res['valid_metrics']),
                             json.dumps(res['test_metrics']),
                         ])
 
-                # Apply best config and run final full training with plots/logging enabled
+                # Log best hyperparameters
                 best = results_list[0] if results_list else None
                 if best is None:
                     self.logger.info("No sweep results found; skipping final training for this combo")
                     continue
+                best_score = best[self.full_args.sweep_metric]
+                best_config = best['config']
+                self.logger.info(f"Best sweep result - {self.full_args.sweep_metric}: {best_score}")
+                self.logger.info(f"Best hyperparameters: {json.dumps(best_config, indent=2)}")
+                print_message(f"Best sweep result for {data_name} with {model_name}:\n"
+                           f"Metric: {self.full_args.sweep_metric} = {best_score}\n"
+                           f"Hyperparameters: {json.dumps(best_config, indent=2)}")
 
-                # Restore base then apply best
+                # Restore base args then apply best
                 self.probe_args.__dict__.update(copy.deepcopy(base_probe))
                 self.trainer_args.__dict__.update(copy.deepcopy(base_trainer))
-                apply_config(best['config'], self.probe_args, self.trainer_args, probe_keys, trainer_keys)
+                apply_config(best_config, self.probe_args, self.trainer_args, probe_keys, trainer_keys)
                 self.trainer_args.make_plots = True
 
-                self.logger.info(f"Running final training with best config for {data_name}/{model_name}")
+                self.logger.info(
+                    f"Training {'probe' if not self.full_args.full_finetuning else 'model'}"
+                    f"for {data_name} with {model_name} with best hyperparameters found by the W&B sweep."
+                    f"Sweep details saved under {self.full_args.log_dir}/"
+)
                 if self.full_args.full_finetuning:
                     _ = self._run_full_finetuning(model_name, data_name, train_set, valid_set, test_set, ppi, sweep_mode=False)
                 elif self.full_args.hybrid_probe:

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -423,7 +423,6 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
                     trainer_base_model=self.trainer_base_model,
                     trainer_hybrid_model=self.trainer_hybrid_model,
                     trainer_probe=self.trainer_probe,
-                    results_list=results_list,
                 )
                 wb_sweep = {
                     "method": method,

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import yaml
 from types import SimpleNamespace
+from .hyperopt_utils import select_metric, apply_config, create_objective_function
 
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
@@ -104,13 +105,27 @@ def parse_arguments():
     parser.add_argument("--full_finetuning", action="store_true", default=False, help="Full finetuning (default: False).")
     parser.add_argument("--hybrid_probe", action="store_true", default=False, help="Hybrid probe (default: False).")
 
+    # ----------------- W&B Arguments ----------------- #
+    parser.add_argument("--use_wandb_hyperopt", action="store_true", default=False, help="Use Weights & Biases hyperparameter optimization.")
+    parser.add_argument("--wandb_project", type=str, default="Protify", help="W&B project name for sweeps.")
+    parser.add_argument("--wandb_entity", type=str, default=None, help="W&B entity (team/user) for sweeps.")
+    parser.add_argument("--sweep_config_path", type=str, default='yamls/sweep_config.yaml', help="Path to W&B sweep config YAML.")
+    parser.add_argument("--sweep_count", type=int, default=10, help="Number of hyperparameter trials to run in the sweep.")
+    parser.add_argument("--sweep_method", type=str, default="bayes", choices=["bayes", "grid", "random"], help="Sweep method for hyperparameter optimization.")
+    parser.add_argument("--sweep_metric", type=str, default="mcc", help="Metric to optimize during sweep.")
+    parser.add_argument("--sweep_goal", type=str, default='maximize', choices=['maximize', 'minimize'], help="Goal for the sweep metric (maximize/minimize)")
     args = parser.parse_args()
 
     if args.hf_token is not None:
         from huggingface_hub import login
         login(args.hf_token)
     if args.wandb_api_key is not None:
-        print_message('Wandb not integrated yet')
+        try:
+            import wandb
+            wandb.login(key=args.wandb_api_key)
+            print_message('Logged into Weights & Biases')
+        except Exception as e:
+            print_message(f'W&B login failed: {e}')
     if args.synthyra_api_key is not None:
         print_message('Synthyra API not integrated yet')
 
@@ -122,6 +137,14 @@ def parse_arguments():
         yaml_args.hf_home = args.hf_home
         yaml_args.synthyra_api_key = args.synthyra_api_key
         yaml_args.wandb_api_key = args.wandb_api_key
+        yaml_args.use_wandb_hyperopt = args.use_wandb_hyperopt
+        yaml_args.wandb_project = args.wandb_project
+        yaml_args.wandb_entity = args.wandb_entity
+        yaml_args.sweep_config_path = args.sweep_config_path
+        yaml_args.sweep_count = args.sweep_count
+        yaml_args.sweep_method = args.sweep_method
+        yaml_args.sweep_metric = args.sweep_metric
+        yaml_args.sweep_goal = args.sweep_goal
         yaml_args.yaml_path = args.yaml_path
         return yaml_args
     else:
@@ -220,6 +243,7 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
             tokenizer,
             emb_dict=None,
             ppi=False,
+            sweep_mode: bool = False,
         ):
         probe = get_probe(self.probe_args)
         summary(probe)
@@ -235,8 +259,9 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
             ppi=ppi,
             log_id=self.random_id,
         )
-        self.log_metrics(data_name, model_name, valid_metrics, split_name='valid')
-        self.log_metrics(data_name, model_name, test_metrics, split_name='test')
+        if not sweep_mode:
+            self.log_metrics(data_name, model_name, valid_metrics, split_name='valid')
+            self.log_metrics(data_name, model_name, test_metrics, split_name='test')
         return probe
 
     def _run_full_finetuning(
@@ -247,6 +272,7 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
             valid_set,
             test_set,
             ppi=False,
+            sweep_mode: bool = False,
         ):
         tokenwise = self.probe_args.tokenwise
         num_labels = self.probe_args.num_labels
@@ -265,8 +291,9 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
             ppi=ppi,
             log_id=self.random_id,
         )
-        self.log_metrics(data_name, model_name, valid_metrics, split_name='valid')
-        self.log_metrics(data_name, model_name, test_metrics, split_name='test')
+        if not sweep_mode:
+            self.log_metrics(data_name, model_name, valid_metrics, split_name='valid')
+            self.log_metrics(data_name, model_name, test_metrics, split_name='test')
         return model
 
     def _run_hybrid_probe(
@@ -279,6 +306,7 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
             tokenizer,
             emb_dict=None,
             ppi=False,
+            sweep_mode: bool = False,
         ):
         tokenwise = self.probe_args.tokenwise
         num_labels = self.probe_args.num_labels
@@ -301,9 +329,145 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
             ppi=ppi,
             log_id=self.random_id,
         )
-        self.log_metrics(data_name, model_name, valid_metrics, split_name='valid')
-        self.log_metrics(data_name, model_name, test_metrics, split_name='test')
+        if not sweep_mode:
+            self.log_metrics(data_name, model_name, valid_metrics, split_name='valid')
+            self.log_metrics(data_name, model_name, test_metrics, split_name='test')
         return model
+
+    @log_method_calls
+    def run_wandb_hyperopt(self):
+        import copy
+        import json
+        import wandb
+        # Load sweep config
+        if self.full_args.sweep_config_path is not None and os.path.exists(self.full_args.sweep_config_path):
+            with open(self.full_args.sweep_config_path, 'r') as f:
+                sweep_config = yaml.safe_load(f)
+
+        if self.full_args.full_finetuning:
+            params_to_hyperopt = sweep_config.get("parameters_full", {})
+        else:
+            # use probe settings for both probe and hybrid
+            params_to_hyperopt = sweep_config.get("parameters_probe", {})
+
+        method = self.full_args.sweep_method
+        metric = {"name": self.full_args.sweep_metric, "goal": self.full_args.sweep_goal}
+        early_term = sweep_config.get("early_terminate", None)
+
+        # select_metric function moved to hyperopt_utils.py
+
+        # Keys allowed to be set from sweeps
+        probe_keys = set(['hidden_size','dropout','n_layers','pre_ln','classifier_dim','transformer_dropout','classifier_dropout','n_heads','rotary','lora','lora_r','lora_alpha','lora_dropout','probe_type','tokenwise'])
+        trainer_keys = set(['lr','weight_decay','num_epochs','probe_batch_size','base_batch_size','probe_grad_accum','base_grad_accum','patience','seed'])
+
+        total_combinations = len(self.model_args.model_names) * len(self.datasets)
+        self.logger.info(f"Hyperopt over {total_combinations} model/dataset combinations")
+
+        for model_name in self.model_args.model_names:
+            # Prepare tokenizer and embeddings info if needed
+            tokenizer = get_tokenizer(model_name)
+            test_seq = self.all_seqs[0]
+
+            for data_name, dataset in self.datasets.items():
+                self.logger.info(f"Starting W&B sweep for {data_name} with {model_name}")
+                train_set, valid_set, test_set, num_labels, label_type, ppi = dataset
+
+                # Update task-specific settings
+                self.probe_args.num_labels = num_labels
+                self.probe_args.task_type = label_type
+                self.trainer_args.task_type = label_type
+
+                # Determine input dim and embedding dict if needed
+                emb_dict = None
+                if not self.full_args.full_finetuning:
+                    if self._sql:
+                        save_path = os.path.join(self.embedding_args.embedding_save_dir, f'{model_name}_{self._full}.db')
+                        input_dim = self.get_embedding_dim_sql(save_path, test_seq, tokenizer)
+                    else:
+                        save_path = os.path.join(self.embedding_args.embedding_save_dir, f'{model_name}_{self._full}.pth')
+                        emb_dict = torch_load(save_path)
+                        input_dim = self.get_embedding_dim_pth(emb_dict, test_seq, tokenizer)
+                    self.probe_args.input_dim = input_dim * 2 if (ppi and not self._full) else input_dim
+
+                results_list = []
+
+                # Snapshot current args so we can restore after each trial
+                base_probe = copy.deepcopy(self.probe_args.__dict__)
+                base_trainer = copy.deepcopy(self.trainer_args.__dict__)
+
+                # apply_config function moved to hyperopt_utils.py
+
+                # Create objective function using hyperopt_utils
+                objective = create_objective_function(
+                    model_name=model_name,
+                    data_name=data_name,
+                    dataset=dataset,
+                    base_probe=base_probe,
+                    base_trainer=base_trainer,
+                    probe_args=self.probe_args,
+                    trainer_args=self.trainer_args,
+                    full_args=self.full_args,
+                    sweep_config=sweep_config,
+                    probe_keys=probe_keys,
+                    trainer_keys=trainer_keys,
+                    emb_dict=emb_dict,
+                    ppi=ppi,
+                    random_id=self.random_id,
+                    model=model,
+                    get_base_model_for_training=get_base_model_for_training,
+                    get_probe=get_probe,
+                    wrap_lora=wrap_lora,
+                    trainer_base_model=self.trainer_base_model,
+                    trainer_hybrid_model=self.trainer_hybrid_model,
+                    trainer_probe=self.trainer_probe
+                )
+                wb_sweep = {
+                    "method": method,
+                    "metric": metric,
+                    "early_terminate": early_term,
+                    "parameters": params_to_hyperopt,
+                }
+                sweep_id = wandb.sweep(sweep=wb_sweep, project=self.full_args.wandb_project, entity=self.full_args.wandb_entity)
+                wandb.agent(sweep_id, function=objective, count=self.full_args.sweep_count)
+
+                # Sort, write, and save sweep results
+                results_list.sort(key=lambda x: x['selected_metric'], reverse=True)
+                sweep_log_path = os.path.join(self.full_args.log_dir, f"{self.random_id}_sweep_{data_name}_{model_name}.csv")
+                import csv as csv
+                with open(sweep_log_path, 'w', newline='', encoding='utf-8') as f:
+                    writer = csv.writer(f, delimiter=',')
+                    # header
+                    header = ["rank","wandb_run_id","selected_metric","config","valid_metrics","test_metrics"]
+                    writer.writerow(header)
+                    for idx, res in enumerate(results_list, start=1):
+                        writer.writerow([
+                            idx,
+                            res['wandb_run_id'],
+                            res['selected_metric'],
+                            json.dumps(res['config']),
+                            json.dumps(res['valid_metrics']),
+                            json.dumps(res['test_metrics']),
+                        ])
+
+                # Apply best config and run final full training with plots/logging enabled
+                best = results_list[0] if results_list else None
+                if best is None:
+                    self.logger.info("No sweep results found; skipping final training for this combo")
+                    continue
+
+                # Restore base then apply best
+                self.probe_args.__dict__.update(copy.deepcopy(base_probe))
+                self.trainer_args.__dict__.update(copy.deepcopy(base_trainer))
+                apply_config(best['config'], self.probe_args, self.trainer_args, probe_keys, trainer_keys)
+                self.trainer_args.make_plots = True
+
+                self.logger.info(f"Running final training with best config for {data_name}/{model_name}")
+                if self.full_args.full_finetuning:
+                    _ = self._run_full_finetuning(model_name, data_name, train_set, valid_set, test_set, ppi, sweep_mode=False)
+                elif self.full_args.hybrid_probe:
+                    _ = self._run_hybrid_probe(model_name, data_name, train_set, valid_set, test_set, tokenizer, emb_dict=emb_dict, ppi=ppi, sweep_mode=False)
+                else:
+                    _ = self._run_nn_probe(model_name, data_name, train_set, valid_set, test_set, tokenizer, emb_dict=emb_dict, ppi=ppi, sweep_mode=False)
 
     @log_method_calls
     def run_full_finetuning(self):
@@ -488,7 +652,12 @@ def main(args: SimpleNamespace):
         main.apply_current_settings()
         main.get_datasets()
         print_message(f"Number of sequences: {len(main.all_seqs)}")
-        if main.full_args.full_finetuning:
+        if main.full_args.use_wandb_hyperopt:
+            if not main.full_args.full_finetuning:
+                main.save_embeddings_to_disk()
+            main.run_wandb_hyperopt()
+
+        elif main.full_args.full_finetuning:
             main.run_full_finetuning()
 
         elif main.full_args.hybrid_probe:

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -401,7 +401,6 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
                 # Snapshot current args so we can restore after each trial
                 base_probe = copy.deepcopy(self.probe_args.__dict__)
                 base_trainer = copy.deepcopy(self.trainer_args.__dict__)
-                model, tokenizer = get_base_model_for_training(model_name, tokenwise=self.probe_args.tokenwise, num_labels=self.probe_args.num_labels, hybrid=False)
 
                 objective = create_objective_function(
                     model_name=model_name,

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -2,7 +2,7 @@ import os
 import argparse
 import yaml
 from types import SimpleNamespace
-from .hyperopt_utils import select_metric, apply_config, create_objective_function
+from hyperopt_utils import select_metric, apply_config, create_objective_function
 
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -417,7 +417,6 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
                     emb_dict=emb_dict,
                     ppi=ppi,
                     random_id=self.random_id,
-                    model=model,
                     get_base_model_for_training=get_base_model_for_training,
                     get_probe=get_probe,
                     wrap_lora=wrap_lora,

--- a/src/protify/main.py
+++ b/src/protify/main.py
@@ -339,7 +339,7 @@ class MainProcess(MetricsLogger, DataMixin, TrainerMixin):
         import copy
         import json
         import wandb
-        # Load sweep config
+        sweep_config = {}
         if self.full_args.sweep_config_path is not None and os.path.exists(self.full_args.sweep_config_path):
             with open(self.full_args.sweep_config_path, 'r') as f:
                 sweep_config = yaml.safe_load(f)

--- a/src/protify/model_components/transformer.py
+++ b/src/protify/model_components/transformer.py
@@ -118,7 +118,9 @@ class TransformerConfig(PretrainedConfig):
         expansion_ratio: float = 8 / 3,
         dropout: float = 0.1,
         rotary: bool = True,
+        **kwargs
     ):
+        super().__init__(**kwargs)
         self.hidden_size = hidden_size
         self.n_heads = n_heads
         self.n_layers = n_layers

--- a/src/protify/probes/trainers.py
+++ b/src/protify/probes/trainers.py
@@ -46,6 +46,7 @@ class TrainerArguments:
             full_finetuning: bool = False,
             hybrid_probe: bool = False,
             num_workers: int = 0,
+            make_plots: bool = True,
             **kwargs
     ):
         self.model_save_dir = model_save_dir
@@ -66,6 +67,7 @@ class TrainerArguments:
         self.full_finetuning = full_finetuning
         self.hybrid_probe = hybrid_probe
         self.num_workers = num_workers
+        self.make_plots = make_plots
 
     def __call__(self, probe: Optional[bool] = True):
         if self.train_data_size > 350000:
@@ -161,15 +163,16 @@ class TrainerMixin:
         y_pred, y_true = y_pred.astype(np.float32), y_true.astype(np.float32)
         print_message(f'y_pred: {y_pred.shape}\ny_true: {y_true.shape}\nFinal test metrics: \n{test_metrics}\n')
 
-        output_dir = os.path.join(self.trainer_args.plots_dir, log_id)
-        os.makedirs(output_dir, exist_ok=True)
-        save_path = os.path.join(output_dir, f"{data_name}_{model_name}_{log_id}.png")
-        title = f"{data_name} {model_name} {log_id}"
+        if self.trainer_args.make_plots and self.trainer_args.plots_dir is not None:
+            output_dir = os.path.join(self.trainer_args.plots_dir, log_id)
+            os.makedirs(output_dir, exist_ok=True)
+            save_path = os.path.join(output_dir, f"{data_name}_{model_name}_{log_id}.png")
+            title = f"{data_name} {model_name} {log_id}"
 
-        if task_type == 'regression':
-            regression_ci_plot(y_true, y_pred, save_path, title)
-        else:
-            classification_ci_plot(y_true, y_pred, save_path, title)
+            if task_type == 'regression':
+                regression_ci_plot(y_true, y_pred, save_path, title)
+            else:
+                classification_ci_plot(y_true, y_pred, save_path, title)
 
         if self.trainer_args.save:
             try:

--- a/src/protify/yamls/sweep_full.yaml
+++ b/src/protify/yamls/sweep_full.yaml
@@ -1,0 +1,27 @@
+method: bayes
+metric: {name: mcc, goal: maximize}
+early_terminate: {type: hyperband, min_iter: 10}
+
+parameters:
+  lr:
+    distribution: log_uniform_values
+    min: 0.000001
+    max: 0.0001
+  weight_decay:
+    distribution: log_uniform_values
+    min: 0.000001
+    max: 0.1
+  base_batch_size:
+    values: [4, 8, 16]
+  base_grad_accum:
+    values: [1, 2, 4]
+  num_epochs:
+    values: [3, 5]
+  lora:
+    values: [True, False]
+  lora_r:
+    values: [8, 16, 32]
+  lora_alpha:
+    values: [16, 32, 64]
+  lora_dropout:
+    values: [0.0, 0.01, 0.05]

--- a/src/protify/yamls/sweep_probe.yaml
+++ b/src/protify/yamls/sweep_probe.yaml
@@ -1,0 +1,31 @@
+method: bayes
+metric: {name: mcc, goal: maximize}
+early_terminate: {type: hyperband, min_iter: 10}
+
+parameters:
+  lr:
+    distribution: log_uniform_values
+    min: 0.00001
+    max: 0.01
+  weight_decay:
+    distribution: log_uniform_values
+    min: 0.000001
+    max: 0.1
+  dropout:
+    distribution: uniform
+    min: 0.0
+    max: 0.5
+  hidden_size:
+    values: [512, 1024, 2048, 4096, 8192]
+  n_layers:
+    values: [1, 2, 3]
+  probe_batch_size:
+    values: [32, 64, 128]
+  lora_r:
+    values: [8, 16, 32]
+  lora_alpha:
+    values: [16, 32, 64]
+  lora_dropout:
+    values: [0.0, 0.01, 0.05]
+  probe_pooling_types:
+    values: ["cls", "mean"]

--- a/src/protify/yamls/sweep_transformer_probe.yaml
+++ b/src/protify/yamls/sweep_transformer_probe.yaml
@@ -1,0 +1,41 @@
+method: bayes
+metric: {name: mcc, goal: maximize}
+early_terminate: {type: hyperband, min_iter: 10}
+
+parameters:
+  lr:
+    distribution: log_uniform_values
+    min: 0.00001
+    max: 0.01
+  weight_decay:
+    distribution: log_uniform_values
+    min: 0.000001
+    max: 0.1
+  transformer_dropout:
+    distribution: uniform
+    min: 0.0
+    max: 0.5
+  classifier_dropout:
+    distribution: uniform
+    min: 0.0
+    max: 0.5
+  pre_ln:
+    values: [True, False]
+  classifier_dim:
+    values: [4096, 8192]
+  n_heads:
+    values: [2, 4, 8]
+  hidden_size:
+    values: [512, 1024, 2048, 4096, 8192]
+  n_layers:
+    values: [1, 2]
+  lora_r:
+    values: [8, 16, 32]
+  lora_alpha:
+    values: [16, 32, 64]
+  lora_dropout:
+    values: [0.0, 0.01, 0.05]
+  probe_batch_size:
+    values: [16,32, 64]
+  probe_pooling_types:
+    values: ["cls", "mean"]


### PR DESCRIPTION
This pull request integrates W&B hyperparameter optimization to Protify.

The way it works is:

If you want to run hyperparameter optimization after passing a set of `--model_names` and ``--data_names`` (or ``--data_dirs``) you can add to your CLI ``--use_wandb_hyperopt``. It works with all transfer learning options.

There are a number of arguments you can choose to specify, such as what metric to sweep over, what method (bayes, random, grid), and how many trials to conduct per sweep, among others.

When Random or Random-Transformer has been added to `--model_names``, hyperparameter optimization will not occur for either of those and a regular training run will be conducted with those embeddings.